### PR TITLE
Hide native password controls and add toggles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -279,3 +279,9 @@ input[type='range'].editor-range::-moz-range-thumb {
 input[type='range'].editor-range::-moz-range-thumb:hover {
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 20%, transparent);
 }
+
+input[type="password"]::-ms-reveal,
+input[type="password"]::-ms-clear {
+  display: none;
+}
+ 

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useState, type SyntheticEvent } from "react";
 import { Link, useNavigate } from "react-router";
-import { Mail, Lock, Chrome, Github } from "lucide-react";
+import { Mail, Lock, Eye, EyeOff, Chrome, Github } from "lucide-react";
 import { signIn } from "../../services/authService";
 import { ApiError } from "../../api/errors";
 import { useAuth } from "../../hooks/useAuth";
@@ -11,6 +11,7 @@ export default function LoginPage() {
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
@@ -69,19 +70,33 @@ export default function LoginPage() {
           </div>
 
           <div className="flex flex-col gap-1">
-            <div className="relative group">
-              <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted group-focus-within:text-accent-red transition-colors" />
+            <div className="relative">
+              <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted transition-colors pointer-events-none" />
               <input
-                type="password"
+                type={showPassword ? "text" : "password"}
                 name="password"
                 placeholder="Password"
                 required
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className={`w-full bg-input-bg border rounded-xl py-3.5 pl-12 pr-4 text-accent-white placeholder-muted text-sm font-medium hover:border-dark-border-light focus:border-accent-red transition-all duration-200 ${
+                className={`w-full bg-input-bg border rounded-xl py-3.5 pl-12 pr-12 text-accent-white placeholder-muted text-sm font-medium hover:border-dark-border-light focus:border-accent-red transition-all duration-200 [&::-ms-reveal]:hidden [&::-ms-clear]:hidden [&::-webkit-credentials-auto-fill-button]:hidden ${
                   apiError?.fieldMessage("password") ? "border-red-500" : "border-input-border"
                 }`}
               />
+              {/*
+                onMouseDown + e.preventDefault()
+                it never disappears after the first click.
+              */}
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => setShowPassword((v) => !v)}
+                tabIndex={-1}
+                aria-label={showPassword ? "Hide password" : "Show password"}
+                className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-light hover:text-accent-white transition-colors cursor-pointer"
+              >
+                {showPassword ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
+              </button>
             </div>
             {apiError?.fieldMessage("password") && (
               <p className="text-xs text-red-400 pl-1">{apiError.fieldMessage("password")}</p>

--- a/src/pages/auth/RegisterPage.tsx
+++ b/src/pages/auth/RegisterPage.tsx
@@ -1,9 +1,52 @@
 import { useState, type SyntheticEvent } from "react";
 import { Link, useNavigate } from "react-router";
-import { Mail, Lock, User, Chrome, Github } from "lucide-react";
+import { Mail, Lock, User, Eye, EyeOff, Chrome, Github } from "lucide-react";
 import { signUp } from "../../services/authService";
 import { ApiError } from "../../api/errors";
 import { useAuth } from "../../hooks/useAuth";
+
+function PasswordField({
+  name,
+  placeholder,
+  value,
+  onChange,
+  hasError,
+}: {
+  name: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+  hasError?: boolean;
+}) {
+  const [show, setShow] = useState(false);
+
+  return (
+    <div className="relative">
+      <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted transition-colors pointer-events-none" />
+      <input
+        type={show ? "text" : "password"}
+        name={name}
+        placeholder={placeholder}
+        required
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={`w-full bg-input-bg border rounded-xl py-3.5 pl-12 pr-12 text-accent-white placeholder-muted text-sm font-medium hover:border-dark-border-light focus:border-accent-red transition-all duration-200 [&::-ms-reveal]:hidden [&::-ms-clear]:hidden [&::-webkit-credentials-auto-fill-button]:hidden ${
+          hasError ? "border-red-500" : "border-input-border"
+        }`}
+      />
+      <button
+        type="button"
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => setShow((v) => !v)}
+        tabIndex={-1}
+        aria-label={show ? "Hide password" : "Show password"}
+        className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-light hover:text-accent-white transition-colors cursor-pointer"
+      >
+        {show ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
+      </button>
+    </div>
+  );
+}
 
 export default function RegisterPage() {
   const navigate = useNavigate();
@@ -119,40 +162,26 @@ export default function RegisterPage() {
           </div>
 
           <div className="flex flex-col gap-1">
-            <div className="relative group">
-              <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted group-focus-within:text-accent-red transition-colors" />
-              <input
-                type="password"
-                name="password"
-                placeholder="Password"
-                required
-                value={password}
-                onChange={(e) => { setPassword(e.target.value); setPasswordMismatch(false); }}
-                className={`w-full bg-input-bg border rounded-xl py-3.5 pl-12 pr-4 text-accent-white placeholder-muted text-sm font-medium hover:border-dark-border-light focus:border-accent-red transition-all duration-200 ${
-                  apiError?.fieldMessage("password") ? "border-red-500" : "border-input-border"
-                }`}
-              />
-            </div>
+            <PasswordField
+              name="password"
+              placeholder="Password"
+              value={password}
+              onChange={(v) => { setPassword(v); setPasswordMismatch(false); }}
+              hasError={!!apiError?.fieldMessage("password")}
+            />
             {apiError?.fieldMessage("password") && (
               <p className="text-xs text-red-400 pl-1">{apiError.fieldMessage("password")}</p>
             )}
           </div>
 
           <div className="flex flex-col gap-1">
-            <div className="relative group">
-              <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted group-focus-within:text-accent-red transition-colors" />
-              <input
-                type="password"
-                name="confirmPassword"
-                placeholder="Confirm password"
-                required
-                value={confirmPassword}
-                onChange={(e) => { setConfirmPassword(e.target.value); setPasswordMismatch(false); }}
-                className={`w-full bg-input-bg border rounded-xl py-3.5 pl-12 pr-4 text-accent-white placeholder-muted text-sm font-medium hover:border-dark-border-light focus:border-accent-red transition-all duration-200 ${
-                  passwordMismatch ? "border-red-500" : "border-input-border"
-                }`}
-              />
-            </div>
+            <PasswordField
+              name="confirmPassword"
+              placeholder="Confirm password"
+              value={confirmPassword}
+              onChange={(v) => { setConfirmPassword(v); setPasswordMismatch(false); }}
+              hasError={passwordMismatch}
+            />
             {passwordMismatch && (
               <p className="text-xs text-red-400 pl-1">Passwords do not match.</p>
             )}


### PR DESCRIPTION
add a show/hide toggle to the login and register form. Hide browser reveal/clear buttons via CSS (an issue with edge browser).

🚀 Elevating the User Experience: Beyond Native Password Controls 🔐

I’m thrilled to share a quick win for our latest UI/UX optimization! We’ve officially moved past standard browser defaults to provide a more seamless, branded experience.What’s new:
✨ Custom Show/Hide Toggles: We’ve integrated intuitive toggles into both our Login and Registration forms, putting control back into the hands of the user.
🛠️ Solving for Edge: To ensure cross-browser consistency, we’ve leveraged CSS to hide those pesky native reveal/clear buttons in Microsoft Edge.

It’s all about the details. By refining these micro-interactions, we’re not just building features—we’re building trust and accessibility.